### PR TITLE
Lab5 - add tx error monitor

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -5108,12 +5108,12 @@ def tx_config():
     pass
 
 
-def tx_config_by_key(key, user_input):
+def tx_config_by_key(field, user_input):
     if user_input < 0 or user_input == 0:
         click.echo("threshold for tx error monitor have to be positive")
     config_db = connect_config_db()
     tx_table_name = 'CFG_PORT_TX_ERROR_TABLE'
-    config_db.set_entry(tx_table_name, key, {"value": user_input})
+    config_db.set_entry(tx_table_name, "", {field: user_input})
 
 
 @tx_config.command()

--- a/config/main.py
+++ b/config/main.py
@@ -5101,35 +5101,33 @@ def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, rdrop, ydrop, gdrop, verbos
     if gdrop is not None: command += " -gdrop %d" % gdrop
     if verbose: command += " -vv"
     clicommon.run_command(command, display_cmd=verbose)
-#todo what if the user type config tx_config period with out value??
+
 @config.group()
 def tx_config():
     """config period time and threshold for tx error"""
     pass
 
-# todo: check how to make it generic
+
+def tx_config_by_key(key, user_input):
+    if user_input < 0 or user_input == 0:
+        click.echo("threshold for tx error monitor have to be positive")
+    config_db = connect_config_db()
+    tx_table_name = 'CFG_PORT_TX_ERROR_TABLE'
+    config_db.set_entry(tx_table_name, key, {"value": user_input})
+
+
 @tx_config.command()
 @click.argument("user_tx_period", type=int, required=True)
 def period(user_tx_period):
     """config period time for tx error"""
-    if user_tx_period < 0 or user_tx_period == 0:
-        click.echo("period time for tx error monitor have to be positive")
-    config_db = connect_config_db()
-    tx_table_name = 'CFG_PORT_TX_ERROR_TABLE'
-    tx_period_key = 'polling_period'
-    config_db.set_entry(tx_table_name, tx_period_key, {"value": user_tx_period})
+    tx_config_by_key('polling_period', user_tx_period)
+
 
 @tx_config.command()
 @click.argument("user_tx_threshold", type=int, required=True)
 def threshold(user_tx_threshold):
     """config threshold for tx error"""
-    if user_tx_threshold < 0 or user_tx_threshold == 0:
-        click.echo("threshold for tx error monitor have to be positive")
-    config_db = connect_config_db()
-    tx_table_name = 'CFG_PORT_TX_ERROR_TABLE'
-    tx_threshold_key = 'threshold'
-    config_db.set_entry(tx_table_name, tx_threshold_key, {"value": user_tx_threshold})
-
+    tx_config_by_key('threshold',user_tx_threshold);
 
 #
 # 'pfc' group ('config interface pfc ...')

--- a/config/main.py
+++ b/config/main.py
@@ -124,6 +124,14 @@ def read_json_file(fileName):
         raise Exception(str(e))
     return result
 
+def connect_config_db():
+    """
+    Connects to config_db
+    """
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    return config_db
+
 def _get_breakout_options(ctx, args, incomplete):
     """ Provides dynamic mode option as per user argument i.e. interface name """
     all_mode_options = []
@@ -5093,6 +5101,34 @@ def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, rdrop, ydrop, gdrop, verbos
     if gdrop is not None: command += " -gdrop %d" % gdrop
     if verbose: command += " -vv"
     clicommon.run_command(command, display_cmd=verbose)
+
+@config.group()
+def tx_config():
+    """config period time and threshold for tx error"""
+    pass
+
+# todo: check how to make it generic
+@tx_config.command()
+@click.argument("user_tx_period", type=int, required=True)
+def period(user_tx_period):
+    """config period time for tx error"""
+    if user_tx_period < 0 or user_tx_period == 0:
+        click.echo("period time for tx error monitor have to be positive")
+    config_db = connect_config_db()
+    tx_table_name = 'CFG_PORT_TX_ERROR_TABLE'
+    tx_period_key = 'polling_period'
+    config_db.set_entry(tx_table_name, tx_period_key, {"value": user_tx_period})
+
+@tx_config.command()
+@click.argument("user_tx_threshold", type=int, required=True)
+def threshold(user_tx_threshold):
+    """config threshold for tx error"""
+    if user_tx_threshold < 0 or user_tx_threshold == 0:
+        click.echo("threshold for tx error monitor have to be positive")
+    config_db = connect_config_db()
+    tx_table_name = 'CFG_PORT_TX_ERROR_TABLE'
+    tx_threshold_key = 'threshold'
+    config_db.set_entry(tx_table_name, tx_threshold_key, {"value": user_tx_threshold})
 
 
 #

--- a/config/main.py
+++ b/config/main.py
@@ -5102,18 +5102,20 @@ def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, rdrop, ydrop, gdrop, verbos
     if verbose: command += " -vv"
     clicommon.run_command(command, display_cmd=verbose)
 
+
 @config.group()
 def tx_config():
     """config period time and threshold for tx error"""
     pass
 
+
 # todo: raise click exception
 def tx_config_by_key(field, user_input):
     if user_input < 0 or user_input == 0:
-        click.echo("threshold for tx error monitor have to be positive")
+        click.echo("The threshold and The period time for tx error monitor have to be positive")
     config_db = connect_config_db()
     tx_table_name = 'CFG_PORT_TX_ERROR_TABLE'
-    config_db.set_entry(tx_table_name, " ", {field: user_input})
+    config_db.mod_entry(tx_table_name, "Config", {field: user_input})
 
 
 @tx_config.command()

--- a/config/main.py
+++ b/config/main.py
@@ -5101,7 +5101,7 @@ def ecn(profile, rmax, rmin, ymax, ymin, gmax, gmin, rdrop, ydrop, gdrop, verbos
     if gdrop is not None: command += " -gdrop %d" % gdrop
     if verbose: command += " -vv"
     clicommon.run_command(command, display_cmd=verbose)
-
+#todo what if the user type config tx_config period with out value??
 @config.group()
 def tx_config():
     """config period time and threshold for tx error"""

--- a/config/main.py
+++ b/config/main.py
@@ -5107,13 +5107,13 @@ def tx_config():
     """config period time and threshold for tx error"""
     pass
 
-
+# todo: raise click exception
 def tx_config_by_key(field, user_input):
     if user_input < 0 or user_input == 0:
         click.echo("threshold for tx error monitor have to be positive")
     config_db = connect_config_db()
     tx_table_name = 'CFG_PORT_TX_ERROR_TABLE'
-    config_db.set_entry(tx_table_name, "", {field: user_input})
+    config_db.set_entry(tx_table_name, " ", {field: user_input})
 
 
 @tx_config.command()
@@ -5127,7 +5127,7 @@ def period(user_tx_period):
 @click.argument("user_tx_threshold", type=int, required=True)
 def threshold(user_tx_threshold):
     """config threshold for tx error"""
-    tx_config_by_key('threshold',user_tx_threshold);
+    tx_config_by_key('threshold', user_tx_threshold);
 
 #
 # 'pfc' group ('config interface pfc ...')

--- a/show/main.py
+++ b/show/main.py
@@ -1810,8 +1810,10 @@ def peer(db, peer_ip):
                                 values.get("tx_interval"), values.get("rx_interval"), values.get("multiplier"), values.get("multihop")])
 
     click.echo(tabulate(bfd_body, bfd_headers))
-# todo: understand the cls=AliasedGroup, default_if_no_args=False
-@cli.group(cls=AliasedGroup, default_if_no_args=False)
+
+
+# todo: understand the cls=clicommon.AliasedGroup, default_if_no_args=False
+@cli.group(cls=clicommon.AliasedGroup)
 def tx_error_monitor():
     pass
 

--- a/show/main.py
+++ b/show/main.py
@@ -1812,12 +1812,10 @@ def peer(db, peer_ip):
     click.echo(tabulate(bfd_body, bfd_headers))
 
 
-# todo: understand the cls=clicommon.AliasedGroup, default_if_no_args=False
-@cli.group(cls=clicommon.AliasedGroup)
+@cli.group()
 def tx_error_monitor():
     pass
 
-#todo: change the name to tx_config?
 @tx_error_monitor.command()
 def config():
     """show tx error monitor configuration"""
@@ -1830,7 +1828,6 @@ def config():
 def status():
     """show ports tx error status"""
     db_connector = SonicV2Connector(host="127.0.0.1")
-    # todo: why false?
     db_connector.connect(db_connector.STATE_DB, False)
     tx_table_name = 'STATE_PORT_TX_ERROR_TABLE|'
     pattern = '{}*'.format(tx_table_name)

--- a/show/main.py
+++ b/show/main.py
@@ -1816,13 +1816,15 @@ def peer(db, peer_ip):
 def tx_error_monitor():
     pass
 
+
 @tx_error_monitor.command()
 def config():
     """show tx error monitor configuration"""
     config_db = connect_config_db()
     config_tx_table = config_db.get_table('CFG_PORT_TX_ERROR_TABLE')
-    click.echo('polling period value is %s' % (config_tx_table[' ']['polling_period']))
-    click.echo('threshold value is %s' % (config_tx_table[' ']['threshold']))
+    click.echo('polling period value is %s' % (config_tx_table['Config']['polling_period']))
+    click.echo('threshold value is %s' % (config_tx_table['Config']['threshold']))
+
 
 @tx_error_monitor.command()
 def status():

--- a/show/main.py
+++ b/show/main.py
@@ -1821,8 +1821,8 @@ def config():
     """show tx error monitor configuration"""
     config_db = connect_config_db()
     config_tx_table = config_db.get_table('CFG_PORT_TX_ERROR_TABLE')
-    click.echo('polling period value is %s' % (config_tx_table['']['polling_period']))
-    click.echo('threshold value is %s' % (config_tx_table['']['threshold']))
+    click.echo('polling period value is %s' % (config_tx_table[' ']['polling_period']))
+    click.echo('threshold value is %s' % (config_tx_table[' ']['threshold']))
 
 @tx_error_monitor.command()
 def status():

--- a/show/main.py
+++ b/show/main.py
@@ -1821,8 +1821,8 @@ def config():
     """show tx error monitor configuration"""
     config_db = connect_config_db()
     config_tx_table = config_db.get_table('CFG_PORT_TX_ERROR_TABLE')
-    click.echo('polling period value is %s' % (config_tx_table['polling_period']['value']))
-    click.echo('threshold value is %s' % (config_tx_table['threshold']['value']))
+    click.echo('polling period value is %s' % (config_tx_table['']['polling_period']))
+    click.echo('threshold value is %s' % (config_tx_table['']['threshold']))
 
 @tx_error_monitor.command()
 def status():


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added 4 CLI commands:
1. show tx-error-monitor status
    shows a table with all the ports and their tx error status ("ok" if the tx error is lower than the threshold and "not ok" 
    otherwise.
2. show tx-error-monitor config
    shows the period time and threshold.
3. config tx-error-monitor period <period time>
    set the period time to <period time>
4. config tx-error-monitor threshold <threshold>
    set the threshold to <threshold>

#### How I did it

1. in show/main.py add click group tx_error_monitor with 2 subcommand of status and config
2. in config/main.py, add click group tx_config with two subcommands of period and threshold

#### How to verify it 

1. verify show tx-error-monitor status:
expected for table with 2 columns of oid and status

2. verify show tx-error-monitor config
expected for period time and threshold

3. verify config tx-error-monitor period <period time>:
    3.1 config tx-error-monitor period <period time>
    3.2 show tx-error-monitor status
    3.3 expected to get the new <period time>

4. verify config tx-error-monitor period <period time>:
    4.1 config tx-error-monitor period <period time>
    4.2 show tx-error-monitor status
    4.3 expected to get the new <period time>

#### Previous command output (if the output of a command-line utility has changed)

Not relevant all the commands are new,

#### New command output (if the output of a command-line utility has changed)

admin@sonic:~$ show tx-error-monitor status 
+---------------------+----------+
| oid                 | status   |
+=====================+==========+
| oid:0x10000000001ef | ok       |
+---------------------+----------+
| oid:0x10000000003ff | ok       |
+---------------------+----------+
| oid:0x1000000000462 | ok       |
+---------------------+----------+
| oid:0x100000000059b | ok       |
+---------------------+----------+
| oid:0x100000000018c | ok       |
+---------------------+----------+
| oid:0x100000000035a | ok       |
+---------------------+----------+
| oid:0x10000000003de | ok       |
+---------------------+----------+
| oid:0x1000000000697 | ok       |
+---------------------+----------+
| oid:0x1000000000715 | ok       |
+---------------------+----------+
| oid:0x10000000003bd | ok       |
+---------------------+----------+
| oid:0x10000000002f7 | ok       |
+---------------------+----------+
| oid:0x100000000073f | ok       |
+---------------------+----------+
| oid:0x10000000006c1 | ok       |
+---------------------+----------+
| oid:0x1000000000339 | ok       |
+---------------------+----------+
| oid:0x1000000000643 | ok       |
+---------------------+----------+
| oid:0x10000000002b5 | ok       |
+---------------------+----------+
| oid:0x100000000039c | ok       |
+---------------------+----------+
| oid:0x1000000000273 | ok       |
+---------------------+----------+
| oid:0x10000000001ad | ok       |
+---------------------+----------+
| oid:0x10000000005c5 | ok       |
+---------------------+----------+
| oid:0x10000000001ce | ok       |
+---------------------+----------+
| oid:0x100000000037b | ok       |
+---------------------+----------+
| oid:0x1000000000441 | ok       |
+---------------------+----------+
| oid:0x10000000002d6 | ok       |
+---------------------+----------+
| oid:0x100000000014a | ok       |
+---------------------+----------+
| oid:0x100000000016b | ok       |
+---------------------+----------+
| oid:0x1000000000507 | ok       |
+---------------------+----------+
| oid:0x1000000000571 | ok       |
+---------------------+----------+
| oid:0x1000000000210 | ok       |
+---------------------+----------+
| oid:0x10000000004a4 | ok       |
+---------------------+----------+
| oid:0x100000000066d | ok       |
+---------------------+----------+
| oid:0x1000000000294 | ok       |
+---------------------+----------+
| oid:0x1000000000318 | ok       |
+---------------------+----------+
| oid:0x1000000000231 | ok       |
+---------------------+----------+
| oid:0x10000000005ef | ok       |
+---------------------+----------+
| oid:0x1000000000420 | ok       |
+---------------------+----------+
| oid:0x10000000006eb | ok       |
+---------------------+----------+
| oid:0x1000000000252 | ok       |
+---------------------+----------+
| oid:0x1000000000619 | ok       |
+---------------------+----------+
| oid:0x10000000004c5 | not-ok   |
+---------------------+----------+



admin@sonic:~$ show tx-error-monitor config 
polling period value is 30
threshold value is 5


admin@sonic:~$ config tx-config period 30

admin@sonic:~$ config tx-config threshold 30


