### PR TITLE
Persistent loglevel

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -717,17 +717,10 @@ class DBMigrator():
             if 'pfc_enable' in v:
                 v['pfcwd_sw_enable'] = v['pfc_enable']
                 self.configDB.set_entry('PORT_QOS_MAP', k, v)
-<<<<<<< HEAD
         self.set_version('version_3_0_5')
         return 'version_3_0_5'
 
     def version_3_0_5(self):
-=======
-        self.set_version('version_2_0_5')
-        return 'version_2_0_5'
-
-    def version_2_0_5(self):
->>>>>>> update
         """
         Version 3_0_5
         """
@@ -749,15 +742,9 @@ class DBMigrator():
                         logoutput = key[logoutput_field]
                         self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
                         self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
-<<<<<<< HEAD
                     self.loglevelDB.del(self.loglevelDB.LOGLEVEL_DB, key)
         self.set_version('version_3_0_6')
         return 'version_3_0_6'
-=======
-                    self.loglevelDB.del_table(self.loglevelDB.LOGLEVEL_DB, key)
-        self.set_version('version_2_0_6')
-        return 'version_2_0_6'
->>>>>>> update
 
 
     def version_3_0_6(self):

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -742,7 +742,7 @@ class DBMigrator():
                         logoutput = key[logoutput_field]
                         self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
                         self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
-                    self.loglevelDB.del(self.loglevelDB.LOGLEVEL_DB, key)
+                    self.loglevelDB.del_table(self.loglevelDB.LOGLEVEL_DB, key)
         self.set_version('version_3_0_6')
         return 'version_3_0_6'
 

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -70,7 +70,6 @@ class DBMigrator():
         if self.stateDB is not None:
             self.stateDB.connect(self.stateDB.STATE_DB)
 
-        # todo check
         self.loglevelDB = SonicV2Connector(host='127.0.0.1')
         if self.loglevelDB is not None:
             self.loglevelDB.connect(self.loglevelDB.LOGLEVEL_DB)
@@ -739,15 +738,14 @@ class DBMigrator():
             keys = self.loglevelDB.keys(self.loglevelDB.LOGLEVEL_DB, "*")
             if keys is not None:
                 for key in keys:
-                    if key == "JINJA2_CACHE":
-                        continue
-                    fvs = self.loglevelDB.get_all(self.loglevelDB.LOGLEVEL_DB, key)
-                    component = key.split(":")[1]
-                    loglevel = fvs[loglevel_field]
-                    logoutput = fvs[logoutput_field]
-                    self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
-                    self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
-                    self.loglevelDB.delete(self.loglevelDB.LOGLEVEL_DB, key) ## todo: move outside the if to remove all keys.
+                    if key != "JINJA2_CACHE":
+                        fvs = self.loglevelDB.get_all(self.loglevelDB.LOGLEVEL_DB, key)
+                        component = key.split(":")[1]
+                        loglevel = fvs[loglevel_field]
+                        logoutput = fvs[logoutput_field]
+                        self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
+                        self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
+                        self.loglevelDB.delete(self.loglevelDB.LOGLEVEL_DB, key) ## todo: When we will remove the Jinja2 chace, this line need to get outside from the if scope outside the if scope.
         self.set_version('version_3_0_6')
         return 'version_3_0_6'
 

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -717,10 +717,17 @@ class DBMigrator():
             if 'pfc_enable' in v:
                 v['pfcwd_sw_enable'] = v['pfc_enable']
                 self.configDB.set_entry('PORT_QOS_MAP', k, v)
+<<<<<<< HEAD
         self.set_version('version_3_0_5')
         return 'version_3_0_5'
 
     def version_3_0_5(self):
+=======
+        self.set_version('version_2_0_5')
+        return 'version_2_0_5'
+
+    def version_2_0_5(self):
+>>>>>>> update
         """
         Version 3_0_5
         """
@@ -742,9 +749,15 @@ class DBMigrator():
                         logoutput = key[logoutput_field]
                         self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
                         self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
+<<<<<<< HEAD
                     self.loglevelDB.del(self.loglevelDB.LOGLEVEL_DB, key)
         self.set_version('version_3_0_6')
         return 'version_3_0_6'
+=======
+                    self.loglevelDB.del_table(self.loglevelDB.LOGLEVEL_DB, key)
+        self.set_version('version_2_0_6')
+        return 'version_2_0_6'
+>>>>>>> update
 
 
     def version_3_0_6(self):

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -719,10 +719,6 @@ class DBMigrator():
         self.set_version('version_3_0_5')
         return 'version_3_0_5'
 
-
-
-
-
     def version_3_0_5(self):
         """
         Version 3_0_5
@@ -745,10 +741,9 @@ class DBMigrator():
                         logoutput = fvs[logoutput_field]
                         self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
                         self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
-                        self.loglevelDB.delete(self.loglevelDB.LOGLEVEL_DB, key) ## todo: When we will remove the Jinja2 chace, this line need to get outside from the if scope outside the if scope.
+                    self.loglevelDB.delete(self.loglevelDB.LOGLEVEL_DB, key)
         self.set_version('version_3_0_6')
         return 'version_3_0_6'
-
 
     def version_3_0_6(self):
         """

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -44,7 +44,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_3_0_5'
+        self.CURRENT_VERSION = 'version_3_0_6'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -69,6 +69,11 @@ class DBMigrator():
         self.stateDB = SonicV2Connector(host='127.0.0.1')
         if self.stateDB is not None:
             self.stateDB.connect(self.stateDB.STATE_DB)
+
+        # todo check
+        self.loglevelDB = SonicV2Connector(host='127.0.0.1')
+        if self.loglevelDB is not None:
+            self.loglevelDB.connect(self.loglevelDB.LOGLEVEL_DB)
 
         version_info = device_info.get_sonic_version_info()
         asic_type = version_info.get('asic_type')
@@ -717,9 +722,37 @@ class DBMigrator():
 
     def version_3_0_5(self):
         """
-        Current latest version. Nothing to do here.
+        Version 3_0_5
         """
         log.log_info('Handling version_3_0_5')
+        # Removing LOGLEVEL DB and moving it's content to CONFIG DB
+        # Removing Jinja2_cache
+        log.log_info('Handling version_3_0_5')
+        warmreboot_state = self.stateDB.get(self.stateDB.STATE_DB, 'WARM_RESTART_ENABLE_TABLE|system', 'enable')
+        table_name = "LOGGER"
+        loglevel_field = 'LOGLEVEL'
+        logoutput_field = 'LOGOUTPUT'
+        if warmreboot_state == 'true':
+            keys = self.loglevelDB.keys(self.loglevelDB.LOGLEVEL_DB, "*")
+            if keys is not None:
+                for key in keys:
+                    if key != "JINJA2_CACHE":
+                        component = key.split(":")[1]
+                        loglevel = key[loglevel_field]
+                        logoutput = key[logoutput_field]
+                        self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
+                        self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
+                    self.loglevelDB.del(self.loglevelDB.LOGLEVEL_DB, key)
+        self.set_version('version_3_0_6')
+        return 'version_3_0_6'
+
+
+    def version_3_0_6(self):
+        """
+        Current latest version. Nothing to do here.
+        """
+
+        log.log_info('Handling version_3_0_6')
         return None
 
     def get_version(self):

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -728,7 +728,7 @@ class DBMigrator():
         """
         Version 3_0_5
         """
-        log.log_notice('Handling version_3_0_5')
+        log.log_info('Handling version_3_0_5')
         # Removing LOGLEVEL DB and moving it's content to CONFIG DB
         # Removing Jinja2_cache
         warmreboot_state = self.stateDB.get(self.stateDB.STATE_DB, 'WARM_RESTART_ENABLE_TABLE|system', 'enable')
@@ -736,21 +736,17 @@ class DBMigrator():
             table_name = "LOGGER"
             loglevel_field = "LOGLEVEL"
             logoutput_field = "LOGOUTPUT"
-            log.log_notice('Warm reboot 3_0_5')
             keys = self.loglevelDB.keys(self.loglevelDB.LOGLEVEL_DB, "*")
             if keys is not None:
                 for key in keys:
-                    log.log_notice('Migrating key: ' + key)
                     if key == "JINJA2_CACHE":
                         continue
                     fvs = self.loglevelDB.get_all(self.loglevelDB.LOGLEVEL_DB, key)
                     component = key.split(":")[1]
                     loglevel = fvs[loglevel_field]
                     logoutput = fvs[logoutput_field]
-                    log.log_notice("Setting loglevel: " + loglevel + " output: " + logoutput)
                     self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), loglevel_field, loglevel)
                     self.configDB.set(self.configDB.CONFIG_DB, '{}|{}'.format(table_name, component), logoutput_field, logoutput)
-                    log.log_notice("Deleting key: " +key)
                     self.loglevelDB.delete(self.loglevelDB.LOGLEVEL_DB, key) ## todo: move outside the if to remove all keys.
         self.set_version('version_3_0_6')
         return 'version_3_0_6'

--- a/tests/db_migrator_input/config_db/reclaiming-buffer-warmreboot-expected.json
+++ b/tests/db_migrator_input/config_db/reclaiming-buffer-warmreboot-expected.json
@@ -2043,6 +2043,6 @@
         "admin_status": "up"
     },
     "VERSIONS|DATABASE": {
-        "VERSION": "version_3_0_5"
+        "VERSION": "version_3_0_6"
     }
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

This PR needs to be merged only after the following PR: https://github.com/dprital/sonic-buildimage/pull/12
This PR needs to be merged with this PR: https://github.com/EdenGri/sonic-swss-common/pull/4

#### What I did
Add the ability to the user to save the loglevel and make it persistent to reboot with the support in warm-upgrade. (Not need to add special support for cold/fast reboot since the LOGLEVEL DB flushes during fast/cold reboot).

#### How I did it
Add a new version to the db_migrator that will move the logger tables from the LOGLEVEL DB to the CONFIG DB

#### How to verify it
1. start with a switch that has an old master image (old master means that the VERSION in the config db is 3_0_5 or lower) 
2. install this image to the switch
3. run warm-reboot
4. verify that the LOGLEVEL DB does not contain logger tables -> run redis-cli -n 3 keys "*" (expect to see only the JINJA2CACHE)
5. verify that the logger tables are in the config db -> run redis-cli -n 4 keys "LOGGER|*"

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

