### PR TITLE
Remove unused Jinja2 cache from the LOGLEVEL DB incase of warm-upgrade

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -44,7 +44,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_3_0_5'
+        self.CURRENT_VERSION = 'version_3_0_6'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -69,7 +69,11 @@ class DBMigrator():
         self.stateDB = SonicV2Connector(host='127.0.0.1')
         if self.stateDB is not None:
             self.stateDB.connect(self.stateDB.STATE_DB)
-
+        
+        self.loglevelDB = SonicV2Connector(host='127.0.0.1')
+        if self.loglevelDB is not None:
+            self.loglevelDB.connect(self.loglevelDB.LOGLEVEL_DB)
+        
         version_info = device_info.get_sonic_version_info()
         asic_type = version_info.get('asic_type')
         self.asic_type = asic_type
@@ -717,9 +721,21 @@ class DBMigrator():
 
     def version_3_0_5(self):
         """
-        Current latest version. Nothing to do here.
+        Version 3_0_5
         """
         log.log_info('Handling version_3_0_5')
+        # Removing Jinja2_cache from LOGLEVEL DB
+        warmreboot_state = self.stateDB.get(self.stateDB.STATE_DB, 'WARM_RESTART_ENABLE_TABLE|system', 'enable')
+        if warmreboot_state == 'true':
+            self.loglevelDB.delete_table(self.loglevelDB.LOGLEVEL_DB, 'JINJA2_CACHE')
+        self.set_version('version_3_0_6')
+        return 'version_3_0_6'
+
+    def version_3_0_6(self):
+        """
+        Current latest version. Nothing to do here.
+        """
+        log.log_info('Handling version_3_0_6')
         return None
 
     def get_version(self):


### PR DESCRIPTION
Remove the unused Jinja2 cache from the LOGLEVEL DB incase of warm-upgrade
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Update the DB Migrator to remove the unused jinja2 cache in case of a warm upgrade#### How I did it

#### How I did it
Add a new version to the db_migrator that will delete the JINJA2 cache from the LOGLEVEL DB

#### How to verify it
1. start with a switch that has an old image (old image means that the VERSION in the config db is 3_0_5 or lower)
2. install this image to the switch
3. run warm-reboot
4. verify that the LOGLEVEL DB does not contain jinja2 cache -> run redis-cli -n 3 keys "JIN" (expect to see empty array)

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

